### PR TITLE
Add modules for extended ban list and checking another channel's ban list

### DIFF
--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -38,14 +38,20 @@ class ModuleBanSyncExtban : public Module
 
 	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)
 	{
+		static bool recursing = false;
+		
 		if ((mask.length() > 2) && (mask[0] == 'J') && (mask[1] == ':'))
 		{
+			if (recursing)
+				return MOD_RES_PASSTHRU;
 			std::string rm = mask.substr(2);
 			Channel* channel = ServerInstance->FindChan(rm);
 			if (channel == NULL)
 				return MOD_RES_PASSTHRU;
+			recursing = true;
 			if (channel->IsBanned(user))
 				return MOD_RES_DENY;
+			recursing = false;
 		}
 		return MOD_RES_PASSTHRU;
 	}

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -26,8 +26,8 @@ class ModuleBanSyncExtban : public Module
 		if ((mask.length() > 2) && (mask[0] == 'J') && (mask[1] == ':'))
 		{
 			std::string rm = mask.substr(2);
-            if (ServerInstance->FindChan(rm)->IsBanned(user))
-                return MOD_RES_DENY;
+			if (ServerInstance->FindChan(rm)->IsBanned(user))
+				return MOD_RES_DENY;
 		}
 		return MOD_RES_PASSTHRU;
 	}

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -24,16 +24,11 @@
 
 class ModuleBanSyncExtban : public Module
 {
- private:
  public:
 	void init()
 	{
 		Implementation eventlist[] = { I_OnCheckBan, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
-	}
-
-	~ModuleBanSyncExtban()
-	{
 	}
 
 	Version GetVersion()

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -26,9 +26,6 @@ class ModuleBanSyncExtban : public Module
 		if ((mask.length() > 2) && (mask[0] == 'J') && (mask[1] == ':'))
 		{
 			std::string rm = mask.substr(2);
-			ModeHandler* mh = ServerInstance->Modes->FindPrefix(rm[0]);
-			if (mh)
-				rm = mask.substr(3);
             if (ServerInstance->FindChan(rm)->IsBanned(user))
                 return MOD_RES_DENY;
 		}

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -1,0 +1,45 @@
+#include "inspircd.h"
+
+/* $ModDesc: Implements extban +b J: - check bans from other channels */
+
+class ModuleBanSyncExtban : public Module
+{
+ private:
+ public:
+	void init()
+	{
+		Implementation eventlist[] = { I_OnCheckBan, I_On005Numeric };
+		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+	}
+
+	~ModuleBanSyncExtban()
+	{
+	}
+
+	Version GetVersion()
+	{
+		return Version("Extban 'J' - check bans from other channels", VF_OPTCOMMON|VF_VENDOR);
+	}
+
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)
+	{
+		if ((mask.length() > 2) && (mask[0] == 'J') && (mask[1] == ':'))
+		{
+			std::string rm = mask.substr(2);
+			ModeHandler* mh = ServerInstance->Modes->FindPrefix(rm[0]);
+			if (mh)
+				rm = mask.substr(3);
+            if (ServerInstance->FindChan(rm)->IsBanned(user))
+                return MOD_RES_DENY;
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void On005Numeric(std::string &output)
+	{
+		ServerInstance->AddExtBanChar('J');
+	}
+};
+
+MODULE_INIT(ModuleBanSyncExtban)
+

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -46,7 +46,7 @@ class ModuleBanSyncExtban : public Module
 				return MOD_RES_PASSTHRU;
 			std::string rm = mask.substr(2);
 			Channel* channel = ServerInstance->FindChan(rm);
-			if (channel == NULL)
+			if (channel == NULL || channel == c)
 				return MOD_RES_PASSTHRU;
 			recursing = true;
 			if (channel->IsBanned(user))

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -33,7 +33,7 @@ class ModuleBanSyncExtban : public Module
 
 	Version GetVersion()
 	{
-		return Version("Extban 'J' - check bans from other channels", VF_OPTCOMMON|VF_VENDOR);
+		return Version("Extban 'J' - check bans from other channels", VF_OPTCOMMON);
 	}
 
 	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -1,6 +1,26 @@
-#include "inspircd.h"
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2015 NickG365 <nick+inspircd@gameon365.net>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
+/* $ModAuthor: NickG365 */
+/* $ModAuthorMail: nick+inspircd@gameon365.net */
 /* $ModDesc: Implements extban +b J: - check bans from other channels */
+
+#include "inspircd.h"
 
 class ModuleBanSyncExtban : public Module
 {

--- a/src/modules/m_bansync.cpp
+++ b/src/modules/m_bansync.cpp
@@ -41,7 +41,10 @@ class ModuleBanSyncExtban : public Module
 		if ((mask.length() > 2) && (mask[0] == 'J') && (mask[1] == ':'))
 		{
 			std::string rm = mask.substr(2);
-			if (ServerInstance->FindChan(rm)->IsBanned(user))
+			Channel* channel = ServerInstance->FindChan(rm);
+			if (channel == NULL)
+				return MOD_RES_PASSTHRU;
+			if (channel->IsBanned(user))
 				return MOD_RES_DENY;
 		}
 		return MOD_RES_PASSTHRU;

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -90,7 +90,7 @@ class ModuleLargeBanList : public Module
 
 	Version GetVersion()
 	{
-		return Version("Allows increasing the ban list limit for specific channels with channel mode +l (max)");
+		return Version("Allows increasing the ban list limit for specific channels with channel mode +E (max)");
 	}
 };
 

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -81,7 +81,7 @@ class ModuleLargeBanList : public Module
 
 	Version GetVersion()
 	{
-		return Version("Allows increasing the ban list limit for specific channels with channel mode +l (max)", VF_VENDOR);
+		return Version("Allows increasing the ban list limit for specific channels with channel mode +l (max)");
 	}
 };
 

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -33,17 +33,17 @@ class LargeBanListMode : public ModeHandler
 
 	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string &parameter, bool adding)
 	{
-        // Removing mode that wasn't set
+		// Removing mode that wasn't set
 		if (channel->IsModeSet(this) == false && !adding)
 			return MODEACTION_DENY;
-        // Removing mode
+		// Removing mode
 		if (channel->IsModeSet(this) && !adding)
-        {
+		{
 			ServerInstance->Config->maxbans[channel->name] = ServerInstance->Config->maxbans.count("*") ? ServerInstance->Config->maxbans["*"] : 64;
 			channel->ResetMaxBans();
 			return MODEACTION_ALLOW;
 		}
-        // Adding or updating mode
+		// Adding or updating mode
 		long newmax = strtol(parameter.c_str(), NULL, 10);
 		if (newmax == channel->GetMaxBans() || newmax == (ServerInstance->Config->maxbans.count("*") ? ServerInstance->Config->maxbans["*"] : 64))
 			return MODEACTION_DENY;

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -1,0 +1,72 @@
+#include <stdlib.h>
+#include "inspircd.h"
+
+/* $ModDesc: Allows increasing the ban list limit for specific channels with channel mode +E (max) */
+
+class LargeBanListMode : public ModeHandler
+{
+ public:
+	LargeBanListMode(Module* Creator) : ModeHandler(Creator, "largebanlist", 'E', PARAM_SETONLY, MODETYPE_CHANNEL)
+	{
+		oper = true;
+	}
+
+	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string &parameter, bool adding)
+	{
+		if (channel->IsModeSet(this) == adding)
+			return MODEACTION_DENY;
+        long newmax = strtol(parameter.c_str(), NULL, 10);
+        if (newmax <= channel->GetMaxBans())
+            return MODEACTION_DENY;
+        ServerInstance->Config->maxbans[channel->name] = newmax;
+        channel->ResetMaxBans();
+		channel->SetModeParam(this, parameter);
+		return MODEACTION_ALLOW;
+	}
+};
+
+class ModuleLargeBanList : public Module
+{
+ private:
+	LargeBanListMode mode;
+ public:
+	ModuleLargeBanList() : mode(this)
+	{
+	}
+
+	void init()
+	{
+		ServerInstance->Modules->AddService(mode);
+
+        Implementation eventlist[] = { I_OnRehash };
+		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+
+		OnRehash(NULL);
+	}
+
+	~ModuleLargeBanList()
+	{
+	}
+
+	void OnRehash(User* user)
+	{
+        for (chan_hash::iterator i = ServerInstance->chanlist->begin(); i != ServerInstance->chanlist->end(); )
+        {
+            Channel* channel = i->second;
+            ++i;
+            if (channel->IsModeSet('E'))
+            {
+                long newmax = strtol(channel->GetModeParameter('E').c_str(), NULL, 10);
+                ServerInstance->Config->maxbans[channel->name] = newmax;
+                channel->ResetMaxBans();
+            }
+        }
+	}
+
+	Version GetVersion()
+	{
+		return Version("Allows increasing the ban list limit for specific channels with channel mode +l (max)", VF_VENDOR);
+	}
+};
+
+MODULE_INIT(ModuleLargeBanList)

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -15,11 +15,11 @@ class LargeBanListMode : public ModeHandler
 	{
 		if (channel->IsModeSet(this) == adding)
 			return MODEACTION_DENY;
-        long newmax = strtol(parameter.c_str(), NULL, 10);
-        if (newmax <= channel->GetMaxBans())
-            return MODEACTION_DENY;
-        ServerInstance->Config->maxbans[channel->name] = newmax;
-        channel->ResetMaxBans();
+		long newmax = strtol(parameter.c_str(), NULL, 10);
+		if (newmax <= channel->GetMaxBans())
+			return MODEACTION_DENY;
+		ServerInstance->Config->maxbans[channel->name] = newmax;
+		channel->ResetMaxBans();
 		channel->SetModeParam(this, parameter);
 		return MODEACTION_ALLOW;
 	}
@@ -38,7 +38,7 @@ class ModuleLargeBanList : public Module
 	{
 		ServerInstance->Modules->AddService(mode);
 
-        Implementation eventlist[] = { I_OnRehash };
+		Implementation eventlist[] = { I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 
 		OnRehash(NULL);
@@ -50,17 +50,17 @@ class ModuleLargeBanList : public Module
 
 	void OnRehash(User* user)
 	{
-        for (chan_hash::iterator i = ServerInstance->chanlist->begin(); i != ServerInstance->chanlist->end(); )
-        {
-            Channel* channel = i->second;
-            ++i;
-            if (channel->IsModeSet('E'))
-            {
-                long newmax = strtol(channel->GetModeParameter('E').c_str(), NULL, 10);
-                ServerInstance->Config->maxbans[channel->name] = newmax;
-                channel->ResetMaxBans();
-            }
-        }
+		for (chan_hash::iterator i = ServerInstance->chanlist->begin(); i != ServerInstance->chanlist->end(); )
+		{
+			Channel* channel = i->second;
+			++i;
+			if (channel->IsModeSet('E'))
+			{
+				long newmax = strtol(channel->GetModeParameter('E').c_str(), NULL, 10);
+				ServerInstance->Config->maxbans[channel->name] = newmax;
+				channel->ResetMaxBans();
+			}
+		}
 	}
 
 	Version GetVersion()

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -1,7 +1,27 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2015 NickG365 <nick+inspircd@gameon365.net>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* $ModAuthor: NickG365 */
+/* $ModAuthorMail: nick+inspircd@gameon365.net */
+/* $ModDesc: Allows increasing the ban list limit for specific channels with channel mode +E (max) */
+
 #include <stdlib.h>
 #include "inspircd.h"
-
-/* $ModDesc: Allows increasing the ban list limit for specific channels with channel mode +E (max) */
 
 class LargeBanListMode : public ModeHandler
 {

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -33,10 +33,19 @@ class LargeBanListMode : public ModeHandler
 
 	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string &parameter, bool adding)
 	{
-		if (channel->IsModeSet(this) == adding)
+        // Removing mode that wasn't set
+		if (channel->IsModeSet(this) == false && !adding)
 			return MODEACTION_DENY;
+        // Removing mode
+		if (channel->IsModeSet(this) && !adding)
+        {
+			ServerInstance->Config->maxbans[channel->name] = ServerInstance->Config->maxbans.count("*") ? ServerInstance->Config->maxbans["*"] : 64;
+			channel->ResetMaxBans();
+			return MODEACTION_ALLOW;
+		}
+        // Adding or updating mode
 		long newmax = strtol(parameter.c_str(), NULL, 10);
-		if (newmax <= channel->GetMaxBans())
+		if (newmax == channel->GetMaxBans() || newmax == (ServerInstance->Config->maxbans.count("*") ? ServerInstance->Config->maxbans["*"] : 64))
 			return MODEACTION_DENY;
 		ServerInstance->Config->maxbans[channel->name] = newmax;
 		channel->ResetMaxBans();

--- a/src/modules/m_morebans.cpp
+++ b/src/modules/m_morebans.cpp
@@ -64,10 +64,6 @@ class ModuleLargeBanList : public Module
 		OnRehash(NULL);
 	}
 
-	~ModuleLargeBanList()
-	{
-	}
-
 	void OnRehash(User* user)
 	{
 		for (chan_hash::iterator i = ServerInstance->chanlist->begin(); i != ServerInstance->chanlist->end(); )


### PR DESCRIPTION
m_morebans provides channel mode E, which can only be set by network operators and accepts an integer parameter to set the maximum bans the channel can have.

m_bansync provides extban J, allowing another channel's ban list to be included when checking bans.

Basic testing with a single server has been done on both.
